### PR TITLE
For a POST 201 is valid (and arguably more correct than 200) for the authentication call.

### DIFF
--- a/Library/PTPusherChannelAuthorizationOperation.m
+++ b/Library/PTPusherChannelAuthorizationOperation.m
@@ -47,7 +47,7 @@
 {
   [super finish];
   
-  authorized = ([(NSHTTPURLResponse *)URLResponse statusCode] == 200);
+  authorized = ([(NSHTTPURLResponse *)URLResponse statusCode] == 200 || [(NSHTTPURLResponse *)URLResponse statusCode] == 201);
   authorizationData = [responseData objectFromJSONData];
 
   if (self.completionHandler) {


### PR DESCRIPTION
The call to get the authentication credentials should accept a 201 alone with 200.
