### PR TITLE
Fixed a small assumption that bit me.

### DIFF
--- a/Library/PTPusherChannelAuthorizationOperation.m
+++ b/Library/PTPusherChannelAuthorizationOperation.m
@@ -61,7 +61,10 @@
   }
   
   if (!self.isCancelled) { // don't do anything if cancelled
-    authorized = ([(NSHTTPURLResponse *)URLResponse statusCode] == 200 || [(NSHTTPURLResponse *)URLResponse statusCode] == 201);
+    authorized = YES;
+    if ([URLResponse isKindOfClass:[NSHTTPURLResponse class]]){
+      authorized = ([(NSHTTPURLResponse *)URLResponse statusCode] == 200 || [(NSHTTPURLResponse *)URLResponse statusCode] == 201);
+	}
     
     if (authorized) {
       authorizationData = [[PTJSON JSONParser] objectFromJSONData:responseData];


### PR DESCRIPTION
NSHTTPURLResponse, since in some cases it might not be. Such as if we're
using a local (within-app) authentication url based on NSURLProtocol.
