### PR TITLE
Prevent crashing when data is nil. 

### DIFF
--- a/Library/PTPusherChannelAuthorizationOperation.m
+++ b/Library/PTPusherChannelAuthorizationOperation.m
@@ -73,8 +73,11 @@
     }
     
     if (authorized) {
-      authorizationData = [[PTJSON JSONParser] objectFromJSONData:responseData];
-      
+      authorizationData = nil;
+      if (responseData != nil) {
+        authorizationData = [[PTJSON JSONParser] objectFromJSONData:responseData];
+      }
+            
       if (![authorizationData isKindOfClass:[NSDictionary class]]) {
         NSDictionary *userInfo = nil;
         


### PR DESCRIPTION
Hi there,

Thank you for your latest commit, i made another small improvement. 

I think the following will crash as well:

[[PTJSON JSONParser] objectFromJSONData:nil]; 

Cheers, Tieme
