### PR TITLE
Added support to send userId and userInfo while authenticating

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -121,6 +121,18 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  */
 @property (nonatomic, strong) NSURL *authorizationURL;
 
+/** The userId of the user subscribing to the prescence channel when authenticating
+ 
+ For more information on channel authorization, [see the Pusher documentation website](http://pusher.com/docs/authenticating_users).
+ */
+@property (nonatomic, strong) NSString *userId;
+
+/** The userInfo of the user subscribing to the prescence channel  when authenticating
+ 
+ For more information on channel authorization, [see the Pusher documentation website](http://pusher.com/docs/authenticating_users).
+ */
+@property (nonatomic, strong) NSDictionary *userInfo;
+
 ///------------------------------------------------------------------------------------/
 /// @name Creating new instances
 ///------------------------------------------------------------------------------------/

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -60,6 +60,8 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 @synthesize reconnectAutomatically;
 @synthesize reconnectDelay;
 @synthesize authorizationURL;
+@synthesize userId;
+@synthesize userInfo;
 
 - (id)initWithConnection:(PTPusherConnection *)connection connectAutomatically:(BOOL)connectAutomatically
 {

--- a/Library/PTPusherChannel.m
+++ b/Library/PTPusherChannel.m
@@ -231,7 +231,7 @@
 
 - (void)authorizeWithCompletionHandler:(void(^)(BOOL, NSDictionary *, NSError *))completionHandler
 {
-  PTPusherChannelAuthorizationOperation *authOperation = [PTPusherChannelAuthorizationOperation operationWithAuthorizationURL:pusher.authorizationURL channelName:self.name socketID:pusher.connection.socketID];
+  PTPusherChannelAuthorizationOperation *authOperation = [PTPusherChannelAuthorizationOperation operationWithAuthorizationURL:pusher.authorizationURL channelName:self.name socketID:pusher.connection.socketID userId:pusher.userId userInfo:pusher.userInfo];
   
   [authOperation setCompletionHandler:^(PTPusherChannelAuthorizationOperation *operation) {
     completionHandler(operation.isAuthorized, operation.authorizationData, operation.error);

--- a/Library/PTPusherChannelAuthorizationOperation.h
+++ b/Library/PTPusherChannelAuthorizationOperation.h
@@ -22,5 +22,5 @@ typedef enum {
 @property (unsafe_unretained, nonatomic, readonly) NSMutableURLRequest *mutableURLRequest;
 @property (nonatomic, readonly) NSError *error;
 
-+ (id)operationWithAuthorizationURL:(NSURL *)URL channelName:(NSString *)channelName socketID:(NSString *)socketID;
++ (id)operationWithAuthorizationURL:(NSURL *)URL channelName:(NSString *)channelName socketID:(NSString *)socketID userId:(NSString *)userId userInfo:(NSDictionary *)userInfo;
 @end

--- a/Library/PTPusherChannelAuthorizationOperation.m
+++ b/Library/PTPusherChannelAuthorizationOperation.m
@@ -33,7 +33,7 @@
   return (NSMutableURLRequest *)URLRequest;
 }
 
-+ (id)operationWithAuthorizationURL:(NSURL *)URL channelName:(NSString *)channelName socketID:(NSString *)socketID
++ (id)operationWithAuthorizationURL:(NSURL *)URL channelName:(NSString *)channelName socketID:(NSString *)socketID userId:(NSString *)userId userInfo:(NSDictionary *)userInfo
 {
   NSAssert(URL, @"URL is required for authorization! (Did you set PTPusher.authorizationURL?)");
   
@@ -50,6 +50,9 @@
   [requestData setObject:socketID forKey:@"socket_id"];
   [requestData setObject:channelName forKey:@"channel_name"];
   
+  if(userId != nil)     [requestData setObject:userId forKey:@"user_id"];
+  if(userInfo != nil)   [requestData setObject:userInfo forKey:@"user_info"];
+    
   [request setHTTPBody:[[requestData sortedQueryString] dataUsingEncoding:NSUTF8StringEncoding]];
   
   return [[self alloc] initWithURLRequest:request];


### PR DESCRIPTION
In the current lib, when authenticating it is not possible to add userdata to the request. 

It is possible add some headers in:

``` objective-c
- (void)pusher:(PTPusher *)pusher willAuthorizeChannelWithRequest:(NSMutableURLRequest *)request
```

but it is hard to alter the post var's there. 

This commit allows you to set the userInfo and userId so the authentication script can use it in the presence_auth method:

e.g:

``` php
echo $pusher->presence_auth($_POST['channel_name'], $_POST['socket_id'],($_POST['user_id'], ($_POST['user_info']);
```
