### PR TITLE
Add a `rake test` task and Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: objective-c
+before_install: sudo gem update --system && bundle install --without scripts
+script: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,12 @@ end
 
 group :building do
   gem "rest-client"
-  gem "xcodebuild-rb", git: "git://github.com/lukeredpath/xcodebuild-rb.git"
+  gem "xcodebuild-rb", :git => "git://github.com/lukeredpath/xcodebuild-rb.git"
   gem "xcodeproj"
   gem "cocoapods", '~> 0.15'
   #gem "xcodeproj", path: File.expand_path("~/Code/repos/cocoapods/external/Xcodeproj")
   #gem "cocoapods", path: File.expand_path("~/Code/repos/cocoapods")
-  gem "github-downloads", git: "git://github.com/lukeredpath/github-downloads.git"
+  gem "github-downloads", :git => "git://github.com/lukeredpath/github-downloads.git"
   gem "osx_keychain"
+  gem "ios-sim-test", :git => "git://github.com/alloy/ios-sim-test.git"
 end

--- a/Podfile
+++ b/Podfile
@@ -17,6 +17,6 @@ end
 target :specs, :exclusive => true do
   link_with ['Functional Specs', 'UnitTests']
   
-  pod 'Kiwi', git: "git://github.com/allending/Kiwi.git", download_only: true
+  pod 'Kiwi', :git => "git://github.com/allending/Kiwi.git", :download_only => true
   pod 'OHHTTPStubs'
 end


### PR DESCRIPTION
This setup allows you to run the unit tests [on TravisCI](https://travis-ci.org/alloy/libPusher/builds/4440510).

The hash syntax changes were needed because the available 1.9.3 version (RVM) is somewhat broken, so this uses the system Ruby (1.8.7).

In the future the test runner + formatter could probably slim down the output even more and add a dot progress formatter.
