### PR TITLE
added pusher:connectionWillConnect: delegate method

### DIFF
--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -261,6 +261,13 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 
 #pragma mark - PTPusherConnection delegate methods
 
+- (void)pusherConnectionWillConnect:(PTPusherConnection *)connection
+{
+    if ([self.delegate respondsToSelector:@selector(pusher:connectionWillConnect:)]) {
+        [self.delegate pusher:self connectionWillConnect:connection];
+    }
+}
+
 - (void)pusherConnectionDidConnect:(PTPusherConnection *)connection
 {
   if ([self.delegate respondsToSelector:@selector(pusher:connectionDidConnect:)]) {

--- a/Library/PTPusherConnection.h
+++ b/Library/PTPusherConnection.h
@@ -14,6 +14,7 @@
 @class PTPusherEvent;
 
 @protocol PTPusherConnectionDelegate <NSObject>
+- (void)pusherConnectionWillConnect:(PTPusherConnection *)connection;
 - (void)pusherConnectionDidConnect:(PTPusherConnection *)connection;
 - (void)pusherConnection:(PTPusherConnection *)connection didDisconnectWithCode:(NSInteger)errorCode reason:(NSString *)reason wasClean:(BOOL)wasClean;
 - (void)pusherConnection:(PTPusherConnection *)connection didFailWithError:(NSError *)error wasConnected:(BOOL)wasConnected;

--- a/Library/PTPusherConnection.m
+++ b/Library/PTPusherConnection.m
@@ -61,6 +61,8 @@ NSString *const PTPusherConnectionPingEvent        = @"pusher:ping";
 {
   if (self.state > PTPusherConnectionClosed)
     return;
+    
+  [self.delegate pusherConnectionWillConnect:self];
   
   socket = [[SRWebSocket alloc] initWithURLRequest:request];
   socket.delegate = self;

--- a/Library/PTPusherDelegate.h
+++ b/Library/PTPusherDelegate.h
@@ -25,6 +25,13 @@
 
 @optional
 
+/** Notifies the delegate that the PTPusher instance is about to connect to the Pusher service.
+ 
+ @param pusher The PTPusher instance that is connecting.
+ @param connection The connection for the pusher instance.
+ */
+- (void)pusher:(PTPusher *)pusher connectionWillConnect:(PTPusherConnection *)connection;
+
 /** Notifies the delegate that the PTPusher instance has connected to the Pusher service successfully.
  
  @param pusher The PTPusher instance that has connected.


### PR DESCRIPTION
Informs the delegate that libPusher is about to connect.
`pusher:connectionDidConnect:` will be called as soon as the connection was successfully established.
