### PR TITLE
Pull requests/avoid nsassert

### DIFF
--- a/Library/PTPusherConnection.m
+++ b/Library/PTPusherConnection.m
@@ -86,9 +86,6 @@ NSString *const PTPusherConnectionPingEvent        = @"pusher:ping";
 
 - (void)send:(id)object
 {
-//    NSAssert(self.isConnected, @"Cannot send data unless connected.");
-//    There is no point for using NSAssert here.
-//    If connection has not been stablished yet, messesage should be ignored instead of forcing the app to crash.
     if (self.isConnected) {
         NSData *JSONData = [[PTJSON JSONParser] JSONDataFromObject:object];
         NSString *message = [[NSString alloc] initWithData:JSONData encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Hi ! 

I don't see the point of using NSAssert here. In some cases, the application could try to send a message before connection is already stablished (Try to subscribe to a presence channel for instance when recovering from background state), and the application crashes if this occur. 
Whether or not this should be fixed in the application, launching an assert don't seems the right procedure to me. 

This message should be ignored instead and keep the normal running. I think it's better to loose a message than crashing the application
