### PR TITLE
ARC iOS 6 compatibility

### DIFF
--- a/Library/PTBlockEventListener.m
+++ b/Library/PTBlockEventListener.m
@@ -21,16 +21,18 @@
     block = [aBlock copy];
     queue = aQueue;
     _invalid = NO;
-    
+#if !OS_OBJECT_USE_OBJC
     dispatch_retain(queue);
+#endif
   }
   return self;
 }
 
 - (void)dealloc
 {
+#if !OS_OBJECT_USE_OBJC
   dispatch_release(queue);
-  
+#endif
 }
 
 - (void)invalidate


### PR DESCRIPTION
dispatch_retain and dispatch_release are not allowed on ARC with iOS6+
