### PR TITLE
weak instead of unsafe_unretained

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -77,7 +77,12 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  
  The delegate must implement the PTPusherDelegate protocol. The delegate is not retained.
  */
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+@property (nonatomic, weak) id<PTPusherDelegate> delegate;
+#else 
 @property (nonatomic, unsafe_unretained) id<PTPusherDelegate> delegate;
+#endif
+
 
 
 /** This property is deprecated and will be ignored.

--- a/Library/PTPusherChannel.h
+++ b/Library/PTPusherChannel.h
@@ -38,7 +38,11 @@
  */
 @interface PTPusherChannel : NSObject <PTPusherEventBindings, PTEventListener> {
   NSString *name;
-  __unsafe_unretained PTPusher *pusher;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+    __weak PTPusher *pusher;
+#else
+    __unsafe_unretained PTPusher *pusher;
+#endif
   PTPusherEventDispatcher *dispatcher;
   NSMutableArray *internalBindings;
 }
@@ -160,7 +164,11 @@
  The presence delegate will be notified of presence channel-specific events, such as the initial
  member list on subscription and member added/removed events.
  */
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+@property (nonatomic, weak) id<PTPusherPresenceChannelDelegate> presenceDelegate;
+#else
 @property (nonatomic, unsafe_unretained) id<PTPusherPresenceChannelDelegate> presenceDelegate;
+#endif
 
 /** Returns the current list of channel members.
  

--- a/Library/PTPusherChannel.m
+++ b/Library/PTPusherChannel.m
@@ -58,7 +58,11 @@
      and the target/action binding object.
      */
     
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+    __weak PTPusherChannel *weakChannel = self;
+#else
     __unsafe_unretained PTPusherChannel *weakChannel = self;
+#endif
     
     [internalBindings addObject:
      [self bindToEventNamed:@"pusher_internal:subscription_succeeded" 
@@ -271,8 +275,13 @@
     eventName = [@"client-" stringByAppendingString:eventName];
   }
   
-  __unsafe_unretained PTPusherChannel *weakSelf = self;
-  __unsafe_unretained PTPusher *weakPusher = pusher;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+    __weak PTPusherChannel *weakSelf = self;
+    __weak PTPusher *weakPusher = pusher;
+#else
+    __unsafe_unretained PTPusherChannel *weakSelf = self;
+    __unsafe_unretained PTPusher *weakPusher = pusher;
+#endif
   
   [clientEventQueue addOperationWithBlock:^{
     [weakPusher sendEventNamed:eventName data:eventData channel:weakSelf.name];
@@ -297,8 +306,12 @@
     /* Set up event handlers for pre-defined channel events.
      As above, use blocks as proxies to a weak channel reference to avoid retain cycles.
      */
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+      __weak PTPusherPresenceChannel *weakChannel = self;
+#else
+      __unsafe_unretained PTPusherPresenceChannel *weakChannel = self;
+#endif
     
-    __unsafe_unretained PTPusherPresenceChannel *weakChannel = self;
     
     [internalBindings addObject:
      [self bindToEventNamed:@"pusher_internal:member_added" 

--- a/Library/PTPusherChannelAuthorizationOperation.h
+++ b/Library/PTPusherChannelAuthorizationOperation.h
@@ -19,7 +19,11 @@ typedef enum {
 @property (nonatomic, copy) void (^completionHandler)(PTPusherChannelAuthorizationOperation *);
 @property (nonatomic, readonly, getter=isAuthorized) BOOL authorized;
 @property (nonatomic, strong, readonly) NSDictionary *authorizationData;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+@property (weak, nonatomic, readonly) NSMutableURLRequest *mutableURLRequest;
+#else
 @property (unsafe_unretained, nonatomic, readonly) NSMutableURLRequest *mutableURLRequest;
+#endif
 @property (nonatomic, readonly) NSError *error;
 
 + (id)operationWithAuthorizationURL:(NSURL *)URL channelName:(NSString *)channelName socketID:(NSString *)socketID;

--- a/Library/PTPusherConnection.h
+++ b/Library/PTPusherConnection.h
@@ -34,7 +34,11 @@ typedef enum {
 
 @interface PTPusherConnection : NSObject <SRWebSocketDelegate>
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+@property (nonatomic, weak) id<PTPusherConnectionDelegate> delegate;
+#else
 @property (nonatomic, unsafe_unretained) id<PTPusherConnectionDelegate> delegate;
+#endif
 @property (nonatomic, readonly, getter=isConnected) BOOL connected;
 @property (nonatomic, copy, readonly) NSString *socketID;
 

--- a/Library/PTPusherEvent.h
+++ b/Library/PTPusherEvent.h
@@ -66,7 +66,11 @@ typedef enum {
 
 /** A textual description of the error.
  */
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 50000
+@property (weak, nonatomic, readonly) NSString *message;
+#else
 @property (unsafe_unretained, nonatomic, readonly) NSString *message;
+#endif
 
 /** The error code. See PTPusherServerErrorCodes for available errors.
  */


### PR DESCRIPTION
It is safer to use weak instead unsafe_unretained. So I added an iOS version comparison on every unsafe_unretained property or variable, so iOS 5+ versions could take advantage of weak benefits keeping iOS 4.3 compatibility
