### PR TITLE
Fixes to podspec

### DIFF
--- a/libPusher.podspec
+++ b/libPusher.podspec
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'SocketRocket', "0.2"
   s.compiler_flags = '-Wno-arc-performSelector-leaks', '-Wno-format'
+  s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'kPTPusherClientLibraryVersion=@\"1.5\"' }
 end


### PR DESCRIPTION
I needed to change these two things to allow updating the libPusher version in the Diagnostic app. It doesn't seem ideal to duplicate the version number though so if you've got any better ideas...?
