### PR TITLE
allows connecting to the EU cluster

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -139,6 +139,16 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  */
 + (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted;
 
+/** Returns a new PTPusher instance with a connection configured with the given key and allows to set different cluster
+ 
+ @param key         Your application's API key. It can be found in the API Access section of your application within the Pusher user dashboard.
+ @param delegate    The delegate for this instance
+ @param isEncrypted If yes, a secure connection over SSL will be established.
+ @param cluster     If set to @"eu", connects to ws-eu.pusher.com
+ */
+
++ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster;
+
 /** Returns a new PTPusher instance with an connection configured with the given key.
  
  Instances created using this method will be encrypted by default. This requires SSL access on your account,

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -18,6 +18,7 @@
 #import "PTPusherChannel_Private.h"
 
 #define kPUSHER_HOST @"ws.pusherapp.com"
+#define kPUSHER_EU_HOST @"ws-eu.pusher.com"
 
 typedef NS_ENUM(NSUInteger, PTPusherAutoReconnectMode) {
   PTPusherAutoReconnectModeNoReconnect,
@@ -109,11 +110,23 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 
 + (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted
 {
-  NSURL *serviceURL = PTPusherConnectionURL(kPUSHER_HOST, key, @"libPusher", isEncrypted);
-  PTPusherConnection *connection = [[PTPusherConnection alloc] initWithURL:serviceURL];
-  PTPusher *pusher = [[self alloc] initWithConnection:connection];
-  pusher.delegate = delegate;
-  return pusher;
+    return [self pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) nil];
+}
+
++ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster
+{
+    NSString * hostURL;
+    if ([cluster isEqual:@"eu"]) {
+        hostURL = kPUSHER_EU_HOST;
+    } else {
+        hostURL = kPUSHER_HOST;
+    }
+    
+    NSURL *serviceURL = PTPusherConnectionURL(hostURL, key, @"libPusher", isEncrypted);
+    PTPusherConnection *connection = [[PTPusherConnection alloc] initWithURL:serviceURL];
+    PTPusher *pusher = [[self alloc] initWithConnection:connection];
+    pusher.delegate = delegate;
+    return pusher;
 }
 
 #pragma mark - Deprecated methods


### PR DESCRIPTION
Adds pusherWithKey:delegate:encrypted:cluster: method. Passing  cluster:@"eu" makes it connect to the eu cluster at ws-eu.pusher.com
