### PR TITLE
Added in ability to set a custom cluster to connect to

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -132,12 +132,22 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
 - (id)initWithConnection:(PTPusherConnection *)connection;
 
 /** Returns a new PTPusher instance with a connection configured with the given key.
- 
+
  @param key         Your application's API key. It can be found in the API Access section of your application within the Pusher user dashboard.
  @param delegate    The delegate for this instance
  @param isEncrypted If yes, a secure connection over SSL will be established.
  */
 + (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted;
+
+/** Returns a new PTPusher instance with a connection configured with the given key and allows to set different cluster
+
+ @param key         Your application's API key. It can be found in the API Access section of your application within the Pusher user dashboard.
+ @param delegate    The delegate for this instance
+ @param isEncrypted If yes, a secure connection over SSL will be established.
+ @param cluster     If set, connects to the provided cluster
+ */
+
++ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster;
 
 /** Returns a new PTPusher instance with an connection configured with the given key.
  

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -109,11 +109,23 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 
 + (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted
 {
-  NSURL *serviceURL = PTPusherConnectionURL(kPUSHER_HOST, key, @"libPusher", isEncrypted);
-  PTPusherConnection *connection = [[PTPusherConnection alloc] initWithURL:serviceURL];
-  PTPusher *pusher = [[self alloc] initWithConnection:connection];
-  pusher.delegate = delegate;
-  return pusher;
+  return [self pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) nil];
+}
+
++ (id)pusherWithKey:(NSString *)key delegate:(id<PTPusherDelegate>)delegate encrypted:(BOOL)isEncrypted cluster:(NSString *) cluster
+{
+    NSString * hostURL;
+    if ([cluster length] == 0) {
+        hostURL = kPUSHER_HOST;
+    } else {
+        hostURL = [NSString stringWithFormat:@"ws-%@.pusher.com", cluster];
+    }
+
+    NSURL *serviceURL = PTPusherConnectionURL(hostURL, key, @"libPusher", isEncrypted);
+    PTPusherConnection *connection = [[PTPusherConnection alloc] initWithURL:serviceURL];
+    PTPusher *pusher = [[self alloc] initWithConnection:connection];
+    pusher.delegate = delegate;
+    return pusher;
 }
 
 #pragma mark - Deprecated methods


### PR DESCRIPTION
As the title describes - added pusherWithKey:delegate:encrypted:cluster: method. By default it still uses the constant defined if no cluster is specified, otherwise it uses the provided one.

Very similar to #149 but just with more freedom.
