### PR TITLE
Added hook for conveniently disabling logging.

### DIFF
--- a/Functional Specs/ClientEventsSpec.m
+++ b/Functional Specs/ClientEventsSpec.m
@@ -67,7 +67,7 @@ describe(@"Client events", ^{
     });
     
     onSubscribe(^(PTPusherChannel *channel) {
-      NSLog(@"here");
+      PTLog(@"here");
     });
     
     [client connect];

--- a/Functional Specs/SpecHelper.m
+++ b/Functional Specs/SpecHelper.m
@@ -81,7 +81,7 @@ void waitForClientToDisconnect(PTPusher *client)
   if (![[PTPusherClientTestHelperDelegate sharedInstance] connected]) return;
 
   while ([[PTPusherClientTestHelperDelegate sharedInstance] connected]) {
-    NSLog(@"Waiting for client to disconnect...");
+    PTLog(@"Waiting for client to disconnect...");
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
   }
 }
@@ -160,7 +160,7 @@ void waitForClientToDisconnect(PTPusher *client)
 - (void)pusher:(PTPusher *)pusher connectionDidConnect:(PTPusherConnection *)connection
 {
   if (self.debugEnabled) {
-    NSLog(@"[DEBUG] Client connected");
+    PTLog(@"[DEBUG] Client connected");
   }
   if (connectedBlock) {
     connectedBlock();
@@ -172,7 +172,7 @@ void waitForClientToDisconnect(PTPusher *client)
 - (void)pusher:(PTPusher *)pusher connection:(PTPusherConnection *)connection didDisconnectWithError:(NSError *)error willAttemptReconnect:(BOOL)willAttemptReconnect
 {
   if (self.debugEnabled) {
-    NSLog(@"[DEBUG] Client disconnected");
+    PTLog(@"[DEBUG] Client disconnected");
   }
   if (disconnectedBlock) {
     disconnectedBlock();
@@ -187,7 +187,7 @@ void waitForClientToDisconnect(PTPusher *client)
 - (void)pusher:(PTPusher *)pusher connection:(PTPusherConnection *)connection failedWithError:(NSError *)error
 {
   if (self.debugEnabled) {
-     NSLog(@"[DEBUG] Client connection failed with error %@", error);
+     PTLog(@"[DEBUG] Client connection failed with error %@", error);
   }
   connected = NO;
   connectedBlock = nil;

--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -42,6 +42,12 @@ extern NSString *const PTPusherFatalErrorDomain;
  */
 extern NSString *const PTPusherErrorUnderlyingEventKey;
 
+/** The key which determines whether or not logging is enabled. 
+ *
+ * Default is true.
+ */
+extern BOOL ptLoggingEnabled;
+
 @class PTPusherChannel;
 @class PTPusherPresenceChannel;
 @class PTPusherPrivateChannel;

--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -46,7 +46,7 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  *
  * Default is true.
  */
-extern BOOL ptLoggingEnabled;
+extern BOOL PTLoggingEnabled;
 
 @class PTPusherChannel;
 @class PTPusherPresenceChannel;

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -19,6 +19,8 @@
 
 #define kPUSHER_HOST @"ws.pusherapp.com"
 
+
+
 typedef NS_ENUM(NSUInteger, PTPusherAutoReconnectMode) {
   PTPusherAutoReconnectModeNoReconnect,
   PTPusherAutoReconnectModeReconnectImmediately,
@@ -33,6 +35,7 @@ NSString *const PTPusherEventUserInfoKey          = @"PTPusherEventUserInfoKey";
 NSString *const PTPusherErrorDomain               = @"PTPusherErrorDomain";
 NSString *const PTPusherFatalErrorDomain          = @"PTPusherFatalErrorDomain";
 NSString *const PTPusherErrorUnderlyingEventKey   = @"PTPusherErrorUnderlyingEventKey";
+BOOL ptLoggingEnabled = true;
 
 /** The Pusher protocol version, used to determined which features
  are supported.
@@ -286,7 +289,7 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
   NSParameterAssert(name);
   
   if (self.connection.isConnected == NO) {
-    NSLog(@"Warning: attempting to send event while disconnected. Event will not be sent.");
+    PTLog(@"Warning: attempting to send event while disconnected. Event will not be sent.");
     return;
   }
   

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -35,7 +35,7 @@ NSString *const PTPusherEventUserInfoKey          = @"PTPusherEventUserInfoKey";
 NSString *const PTPusherErrorDomain               = @"PTPusherErrorDomain";
 NSString *const PTPusherFatalErrorDomain          = @"PTPusherFatalErrorDomain";
 NSString *const PTPusherErrorUnderlyingEventKey   = @"PTPusherErrorUnderlyingEventKey";
-BOOL ptLoggingEnabled = true;
+BOOL PTLoggingEnabled = true;
 
 /** The Pusher protocol version, used to determined which features
  are supported.

--- a/Library/PTPusherConnection.m
+++ b/Library/PTPusherConnection.m
@@ -11,6 +11,7 @@
 #define SR_ENABLE_LOG
 #import "SRWebSocket.h"
 #import "PTJSON.h"
+#import "PTPusher.h"
 
 NSString *const PTPusherConnectionEstablishedEvent = @"pusher:connection_established";
 NSString *const PTPusherConnectionPingEvent        = @"pusher:ping";
@@ -34,7 +35,7 @@ NSString *const PTPusherConnectionPongEvent        = @"pusher:pong";
     request = [NSURLRequest requestWithURL:aURL];
     
 #ifdef DEBUG
-    NSLog(@"[pusher] Debug logging enabled");
+    PTLog(@"[pusher] Debug logging enabled");
 #endif
     
     // Timeout defaults as recommended by the Pusher protocol documentation.
@@ -143,7 +144,7 @@ NSString *const PTPusherConnectionPongEvent        = @"pusher:pong";
   
   if ([event.name isEqualToString:PTPusherConnectionPongEvent]) {
 #ifdef DEBUG
-    NSLog(@"[pusher] Server responded to ping (pong!)");
+    PTLog(@"[pusher] Server responded to ping (pong!)");
 #endif
     return;
   }
@@ -177,7 +178,7 @@ NSString *const PTPusherConnectionPongEvent        = @"pusher:pong";
 - (void)handleActivityTimeout
 {
 #ifdef DEBUG
-  NSLog(@"[pusher] Pusher connection activity timeout reached, sending ping to server");
+  PTLog(@"[pusher] Pusher connection activity timeout reached, sending ping to server");
 #endif
   
   [self sendPing];
@@ -188,7 +189,7 @@ NSString *const PTPusherConnectionPongEvent        = @"pusher:pong";
 - (void)handlePongTimeout
 {
 #ifdef DEBUG
-  NSLog(@"[pusher] Server did not respond to ping within timeout, disconnecting");
+  PTLog(@"[pusher] Server did not respond to ping within timeout, disconnecting");
 #endif
   
   [self disconnect];

--- a/Library/PTPusherEvent.m
+++ b/Library/PTPusherEvent.m
@@ -6,6 +6,7 @@
 //  Copyright 2010 LJR Software Limited. All rights reserved.
 //
 
+#import "PTPusher.h"
 #import "PTPusherEvent.h"
 #import "PTJSON.h"
 
@@ -35,7 +36,7 @@ NSString *const PTPusherChannelKey = @"channel";
       _data = [[[PTJSON JSONParser] objectFromJSONString:data] copy];
 
       if (_data == nil) {
-        NSLog(@"[pusher] Error parsing event data (not JSON?)");
+        PTLog(@"[pusher] Error parsing event data (not JSON?)");
         _data = [data copy];
       }
     }

--- a/Library/PTPusherMacros.h
+++ b/Library/PTPusherMacros.h
@@ -19,4 +19,12 @@ _sharedObject = block(); \
 }); \
 return _sharedObject; \
 
+#define PTLog(log, ...) \
+do { \
+  if (ptLoggingEnabled) { \
+    NSLog(log, ##__VA_ARGS__); \
+  } \
+} while(0)
+
+
 #endif

--- a/Library/PTPusherMacros.h
+++ b/Library/PTPusherMacros.h
@@ -21,7 +21,7 @@ return _sharedObject; \
 
 #define PTLog(log, ...) \
 do { \
-  if (ptLoggingEnabled) { \
+  if (PTLoggingEnabled) { \
     NSLog(log, ##__VA_ARGS__); \
   } \
 } while(0)


### PR DESCRIPTION
I generally like to keep my debugger clean and void of third party frameworks/libraries logs. Added in a variable that, if set to false, disables all logging for libPusher. 
## Usage:
### Former:

```
NSLog(@"%@ %@ %@", @"cat", @"dog", @"horse")
```
### New:

```
PTLog(@"%@ %@ %@", @"cat", @"dog", @"horse")
```
## To disable logging:

```
// Set the global flag to false
PTLoggingEnabled = NO;

// Initialize pusher client as usual. If the global flag is toggled at anytime throughout the lifetime of the client, logging will be enabled/disabled appropriately.
self.pusherClient = [PTPusher pusherWithKey:PUSHER_API_KEY delegate:self encrypted:YES];
```

If merged, all logging should be under PTLog(...) rather than NSLog(...) in the future.
