### PR TITLE
Add tvOS as a deployment target

### DIFF
--- a/libPusher.podspec
+++ b/libPusher.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
 
   s.subspec 'Core' do |subspec|
     subspec.dependency 'SocketRocket', '0.5.1'


### PR DESCRIPTION
Relies on SocketRocket having tvOS added as a deployment target too (https://github.com/square/SocketRocket/pull/282).

Currently Cocoapods Core doesn't have support for tvOS as a deployment target either, so it's a bit pre-emptive.

I've tested it in this (https://github.com/hamchapman/libPusherTVOSTest) app and it was all working as expected there.
