### PR TITLE
v1.6 exposing channels dictionary (immutable) to see what channels are currently subscribed

### DIFF
--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -253,10 +253,10 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
 - (PTPusherChannel *)channelNamed:(NSString *)name;
 
 
-/** Returns a dictionary of previously subscribed channels.
+/** Returns a shallow copy dictionary of previously subscribed channels.
 
  */
-- (NSDictionary*)subscribedChannels;
+- (NSDictionary *)subscribedChannels;
 
 ///------------------------------------------------------------------------------------/
 /// @name Publishing events

--- a/Library/PTPusher.h
+++ b/Library/PTPusher.h
@@ -252,6 +252,12 @@ extern NSString *const PTPusherErrorUnderlyingEventKey;
  */
 - (PTPusherChannel *)channelNamed:(NSString *)name;
 
+
+/** Returns a dictionary of previously subscribed channels.
+
+ */
+- (NSDictionary*)subscribedChannels;
+
 ///------------------------------------------------------------------------------------/
 /// @name Publishing events
 ///------------------------------------------------------------------------------------/

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -207,8 +207,9 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
   return channels[name];
 }
 
-- (NSDictionary*)subscribedChannels {
-  return (NSDictionary*)channels;
+- (NSDictionary *)subscribedChannels
+{
+  return [[NSDictionary alloc] initWithDictionary:channels copyItems:NO];
 }
 
 /* This is only called when a client explicitly unsubscribes from a channel

--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -207,6 +207,10 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
   return channels[name];
 }
 
+- (NSDictionary*)subscribedChannels {
+  return (NSDictionary*)channels;
+}
+
 /* This is only called when a client explicitly unsubscribes from a channel
  * by calling either [channel unsubscribe] or using the deprecated API 
  * [client unsubscribeFromChannel:].


### PR DESCRIPTION
created a method to return an immutable reference to the channels dictionary to see what channels are currently subscribed