### PR TITLE
Expose public header files correctly

### DIFF
--- a/libPusher.podspec
+++ b/libPusher.podspec
@@ -13,6 +13,8 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.9'
 
+  s.public_header_files = 'Library/*.h'
+  
   s.subspec 'Core' do |subspec|
     subspec.dependency 'SocketRocket', '0.5.1'
 


### PR DESCRIPTION
While using the library via cocoapods with `use_frameworks!`, the app cannot compile properly because the file `PTURLRequestOperation.h` is not exposed as header (it was recently moved from `Library/Private Headears` to `Library`.

With this change, all public header files are correctly exposed (while leaving private headers... private) and so the app can compile properly.
