### PR TITLE
Ensure socket IDs still match before proceeding with subscription

### DIFF
--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -282,10 +282,12 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
 - (void)subscribeToChannel:(PTPusherChannel *)channel
 {
   if (channel.isPrivate) {
-    [self.channelAuthorizationDelegate pusherChannel:channel requiresAuthorizationForSocketID:self.connection.socketID completionHandler:^(BOOL isAuthorized, NSDictionary *authData, NSError *error) {
-
+    NSString *socketID = self.connection.socketID;
+    [self.channelAuthorizationDelegate pusherChannel:channel requiresAuthorizationForSocketID:socketID completionHandler:^(BOOL isAuthorized, NSDictionary *authData, NSError *error) {
+      
       if (!self.connection.isConnected) return;
-
+      if (self.connection.socketID != socketID) return; // Socket may have changed since the auth request was made
+      
       if (isAuthorized) {
         [channel subscribeWithAuthorization:authData];
       }


### PR DESCRIPTION
It's possible that while the auth request is in progress, the connection's
socket ID changes, perhaps due to a disconnect/reconnect.

Prior to this change the subscription attempt would still proceed and
result in an "Invalid signature" error. This was mostly benign, as another
auth request was queued up with the correct socket ID, but it does
cause unnecessary errors on both the client and on Pusher, making it
harder to find legitimate issues.