### PR TITLE
fix invalid host with cluster set

### DIFF
--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -109,7 +109,7 @@ NSURL *PTPusherConnectionURL(NSString *host, NSString *key, NSString *clientID, 
     if ([cluster length] == 0) {
         hostURL = kPUSHER_HOST;
     } else {
-        hostURL = [NSString stringWithFormat:@"ws-%@.pusher.com", cluster];
+        hostURL = [NSString stringWithFormat:@"ws-%@.pusherapp.com", cluster];
     }
 
     NSURL *serviceURL = PTPusherConnectionURL(hostURL, key, @"libPusher", isEncrypted);


### PR DESCRIPTION
if cluster is set then pusher.com is used. but if cluster in nil, then pusherapp.com is used. pusher.com does not work for me!