### PR TITLE
allow fragments when reading json

### DIFF
--- a/Library/PTJSON.m
+++ b/Library/PTJSON.m
@@ -43,7 +43,7 @@
 
 - (id)objectFromJSONData:(NSData *)data
 {
-  return [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+  return [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
 }
 
 - (id)objectFromJSONString:(NSString *)string


### PR DESCRIPTION
I think that this library shouldn't care about the detailed structure of the underlying json that it is passing along