### PR TITLE
Add supported platforms to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ PTPusherChannel *channel = [self.client subscribeToChannelNamed:@"chat"];
 [self.client connect];
 ```
 
+## Supported platforms
+### Deployment targets
+- iOS 6.0 and above
+- macOS (OS X) 10.9 and above
+
 ## Installation
 
 Install using CocoaPods is recommended.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ PTPusherChannel *channel = [self.client subscribeToChannelNamed:@"chat"];
 [self.client connect];
 ```
 
-## Looking for the push notifications beta?
-
-Head over to the [push-notifications](https://github.com/pusher/libPusher/tree/push-notifications) branch.
-
 ## Installation
 
 Install using CocoaPods is recommended.


### PR DESCRIPTION
This PR adds a list of supported platforms to the README. It also removes the link to the push notifications beta. That product has now been discontinued and replaced by [Pusher Beams](https://pusher.com/beams), which has its own SDK.