### PR TITLE
Fix header imports of SocketRocket.h

### DIFF
--- a/Library/PTPusher.m
+++ b/Library/PTPusher.m
@@ -16,7 +16,7 @@
 #import "PTPusherErrors.h"
 #import "PTPusherChannelServerBasedAuthorization.h"
 #import "PTPusherChannel_Private.h"
-#import "SRWebSocket.h"
+#import <SocketRocket/SRWebSocket.h>
 
 #define kPUSHER_HOST @"ws.pusherapp.com"
 

--- a/Library/PTPusherConnection.m
+++ b/Library/PTPusherConnection.m
@@ -9,7 +9,7 @@
 #import "PTPusherConnection.h"
 #import "PTPusherEvent.h"
 #define SR_ENABLE_LOG
-#import "SRWebSocket.h"
+#import <SocketRocket/SRWebSocket.h>
 #import "PTJSON.h"
 
 NSString *const PTPusherConnectionEstablishedEvent = @"pusher:connection_established";

--- a/Library/PTPusherMockConnection.m
+++ b/Library/PTPusherMockConnection.m
@@ -9,7 +9,7 @@
 #import "PTPusherMockConnection.h"
 #import "PTJSON.h"
 #import "PTPusherEvent.h"
-#import "SRWebSocket.h"
+#import <SocketRocket/SRWebSocket.h>
 
 @interface PTPusherConnection () <SRWebSocketDelegate>
 @end


### PR DESCRIPTION
**Problem**

CocoaPods 1.7.0 added "Multiple Xcodeproj Generation" for large projects (see http://blog.cocoapods.org/CocoaPods-1.7.0-beta/#multiple-xcodeproj-generation). To enable, one can add the following line to one's `Podfile`:

```
install! 'cocoapods', :generate_multiple_pod_projects => true
```

However, enabling it leads to compilation errors in the latest version of this library (`libPusher v1.6.3`):

<img width="1363" alt="libPusher" src="https://user-images.githubusercontent.com/1138127/71834133-7679e780-307c-11ea-8dae-c8c222e170ca.png">

This is due to `libPusher` importing `SocketRocket.h` without clearly indicating its coming from another framework.

@TomKemp could you take a look? I see that the last published version is more than two years old, so I'm not sure if this library is still actively maintained, but I'd appreciate if this PR could get merged and a new release published to cocoapods master spec repo. Thanks