### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ sudo: false
 before_install:
   - gem install xcpretty
 install:
-  - tail -n +4 Sample\ iOS/Constants.h.example > Sample\ iOS/Constants.h
-  - echo \#define PUSHER_APP_ID @\"$(env | grep PUSHER_APP_ID | cut -d "=" -f 2)\" >> Sample\ iOS/Constants.h
-  - echo \#define PUSHER_API_KEY @\"$(env | grep PUSHER_API_KEY | cut -d "=" -f 2)\" >> Sample\ iOS/Constants.h
-  - echo \#define PUSHER_API_SECRET @\"$(env | grep PUSHER_API_SECRET | cut -d "=" -f 2)\" >> Sample\ iOS/Constants.h
+  - chmod u+x Scripts/travis-set-constants.sh
+  - Scripts/travis-set-constants.sh 
   - bundle install
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.1
+osx_image: xcode11.3
 sudo: false
 before_install:
   - gem install xcpretty
@@ -11,9 +11,9 @@ install:
   - bundle install
 env:
   matrix:
-    - XCODE_SCHEME="libPusher" SDK="iphonesimulator" DESTINATION="OS=10.1,name=iPhone 7"
+    - XCODE_SCHEME="libPusher" SDK="iphonesimulator" DESTINATION="OS=13.3,name=iPhone 11"
     - XCODE_SCHEME="libPusher-OSX" SDK="macosx" DESTINATION="arch=x86_64"
-    - XCODE_SCHEME="Functional Specs" SDK="iphonesimulator" DESTINATION="OS=10.1,name=iPhone 7"
+    - XCODE_SCHEME="Functional Specs" SDK="iphonesimulator" DESTINATION="OS=13.3,name=iPhone 11"
 script:
   - set -o pipefail
   - rackup -p 9292 Scripts/auth_server.ru > logs.txt 2>&1 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ install:
   - bundle install
 env:
   matrix:
-    - XCODE_SCHEME="libPusher" SDK="iphonesimulator" DESTINATION="OS=13.3,name=iPhone 11"
-    - XCODE_SCHEME="libPusher-OSX" SDK="macosx" DESTINATION="arch=x86_64"
-    - XCODE_SCHEME="Functional Specs" SDK="iphonesimulator" DESTINATION="OS=13.3,name=iPhone 11"
+    - XCODE_SCHEME="libPusher" SDK="iphonesimulator" DESTINATION="OS=13.3,name=iPhone 11" ADDITIONAL_ARGUMENTS=""
+    - XCODE_SCHEME="libPusher-OSX" SDK="macosx" DESTINATION="arch=x86_64" ADDITIONAL_ARGUMENTS="MACOSX_DEPLOYMENT_TARGET=10.9"
+    - XCODE_SCHEME="Functional Specs" SDK="iphonesimulator" DESTINATION="OS=13.3,name=iPhone 11" ADDITIONAL_ARGUMENTS=""
 script:
   - set -o pipefail
   - rackup -p 9292 Scripts/auth_server.ru > logs.txt 2>&1 &
-  - xcodebuild -workspace libPusher.xcworkspace -scheme "$XCODE_SCHEME" -sdk "$SDK" test -destination "$DESTINATION" | xcpretty -tc
+  - xcodebuild -workspace libPusher.xcworkspace -scheme "$XCODE_SCHEME" -sdk "$SDK" test -destination "$DESTINATION" $ADDITIONAL_ARGUMENTS | xcpretty -tc

--- a/Scripts/travis-set-constants.sh
+++ b/Scripts/travis-set-constants.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+tail -n +4 Sample\ iOS/Constants.h.example > Sample\ iOS/Constants.h
+echo \#define PUSHER_APP_ID @\"$(env | grep PUSHER_APP_ID | cut -d "=" -f 2)\" >> Sample\ iOS/Constants.h
+echo \#define PUSHER_API_KEY @\"$(env | grep PUSHER_API_KEY | cut -d "=" -f 2)\" >> Sample\ iOS/Constants.h
+echo \#define PUSHER_API_SECRET @\"$(env | grep PUSHER_API_SECRET | cut -d "=" -f 2)\" >> Sample\ iOS/Constants.h


### PR DESCRIPTION
The tests are currently failing on Travis (but they run fine on my own machine). This is due to the Travis configuration rather than the library itself. This PR makes three changes to address that:

1) Update to the latest version of Xcode and iOS simulators
2) Move the `install` commands to a separate script file because these were not behaving correctly within the YAML
3) Set the macOS deployment target for the macOS tests. There is currently no macOS deployment target set in the project. The latest `osx_image` that Travis has available runs macOS 10.14 and has Xcode 11.3 which has a maximum deployment target of 10.15. Because the project has no deployment target, Xcode seems to use the latest possible deployment target to build the project: in this case 10.15. It then runs the tests on the 10.14 machine, which then fail. Therefore I have set the deployment target to 10.9 as a command line parameter. We could set a deployment target in the project itself and as far as I'm aware that should be OK, but there may be other consequences of that change that I am not aware of so it requires further thought. 